### PR TITLE
Fix YARD docstring issues

### DIFF
--- a/lib/semverse/constraint.rb
+++ b/lib/semverse/constraint.rb
@@ -3,7 +3,7 @@ module Semverse
     class << self
       # Coerce the object into a constraint.
       #
-      # @param [Constraint, String]
+      # @param [Constraint, String] object
       #
       # @return [Constraint]
       def coerce(object)

--- a/lib/semverse/version.rb
+++ b/lib/semverse/version.rb
@@ -3,7 +3,7 @@ module Semverse
     class << self
       # Coerce the object into a version.
       #
-      # @param [Version, String]
+      # @param [Version, String] object
       #
       # @return [Version]
       def coerce(object)


### PR DESCRIPTION
This PR fixes issues with YARD docstrings:

```
lib/semverse/version.rb:6: [MissingParamName] @param tag has empty parameter name
lib/semverse/constraint.rb:6: [MissingParamName] @param tag has empty parameter name
```