### PR TITLE
CI: Update matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - rvm: 2.2.10
     - rvm: 2.3.8
-    - rvm: 2.4.5
+    - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 cache: bundler
 bundler_args: --without development
@@ -7,7 +6,7 @@ matrix:
     - rvm: 2.2.10
     - rvm: 2.3.8
     - rvm: 2.4.5
-    - rvm: 2.5.3
+    - rvm: 2.5.5
     - rvm: 2.6
     - rvm: ruby-head
   allow_failures:


### PR DESCRIPTION
This PR removes a Travis setting which has become defunct. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for historical detail about when it was removed.

It also updates the CI matrix versions to the latest release.